### PR TITLE
Backported Kernel Patches and fixed a build error on Kernel 6.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# build artifacts
+*.cmd
+*.ko
+*.o
+*.mod
+*.mod.c
+
+Module.symvers
+modules.order

--- a/hid-winwing.c
+++ b/hid-winwing.c
@@ -29,7 +29,7 @@ struct winwing_led_info {
 	const char *led_name;
 };
 
-static struct winwing_led_info led_info[3] = {
+static const struct winwing_led_info led_info[3] = {
 	{ 0, 255, "backlight" },
 	{ 1, 1, "a-a" },
 	{ 2, 1, "a-g" },
@@ -100,7 +100,7 @@ static int winwing_init_led(struct hid_device *hdev, struct input_dev *input)
 		return -ENOMEM;
 
 	for (i = 0; i < 3; i += 1) {
-		struct winwing_led_info *info = &led_info[i];
+		const struct winwing_led_info *info = &led_info[i];
 
 		led = &data->leds[i];
 		led->hdev = hdev;

--- a/hid-winwing.c
+++ b/hid-winwing.c
@@ -198,7 +198,7 @@ static const __u8 rdesc_buttons_128_fixed[] = {
  * This module skips numbers 32-63, unused on some throttle grips.
  */
 
-static __u8 *winwing_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+static const __u8 *winwing_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 		unsigned int *rsize)
 {
 	if (*rsize < 34)


### PR DESCRIPTION
# Changes
Backported [these changes](https://patchwork.kernel.org/project/linux-input/patch/20240804-hid-const-winwing-v1-1-5a6c714753b1@weissschuh.net/)  from the kernel so that this repo is inline 

# Bug Fix
Noticed that on the latest version of Fedora 41 with Kernel `6.12.7-200.fc41.x86_64`

i was getting the following error
```bash
/home/thomas/Documents/Dev/linux-winwing/hid-winwing.c:309:25: error: initialization of ‘const __u8 * (*)(struct hid_device *, __u8 *, unsigned int *)’ {aka ‘const unsigned char * (*)(struct hid_device *, unsigned char *, unsigned int *)’} from incompatible pointer type ‘__u8 * (*)(struct hid_device *, __u8 *, unsigned int *)’ {aka ‘unsigned char * (*)(struct hid_device *, unsigned char *, unsigned int *)’} [-Wincompatible-pointer-types]
  309 |         .report_fixup = winwing_report_fixup,
  ```
  
 The fix was to add `const` to `winwing_report_fixup` which does seem to work however beyond that i'm unsure of it's impact.